### PR TITLE
Fixed memory leak in pop_back()

### DIFF
--- a/src/QList.h
+++ b/src/QList.h
@@ -137,6 +137,7 @@ void QList<T>::pop_back()
 		end->next = NULL;
 		else // List became empty so we need to clear start
 		start = NULL;
+		delete tmp;
 		len--; // Decrease counter
 	}
 }


### PR DESCRIPTION
The "popped" node wasn't getting deleted.