### PR TITLE
Remove obsolete include of .cpp file from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Purpose of this library is to enable programmers to create lists of things
 Before we can start using library, we need to include library to our sketch
 ``` C++
   #include <QList.h>
-  #include "QList.cpp" // Use only if IDE shows compile error
 ```
 
 First, we create simple list object example for ints:


### PR DESCRIPTION
https://github.com/SloCompTech/QList/commit/d704bd156cb92d2dca7bdd8be0474b1026883182 removed the file QList.cpp so the #include of that file in the example code in README.md is no longer valid.