### PR TITLE
Move to the next node if it's not the specified index

### DIFF
--- a/src/QList.h
+++ b/src/QList.h
@@ -203,6 +203,8 @@ void QList<T>::clear(unsigned int index)
 			delete tmp; // Delete item
 			break;
 		}
+		else
+		tmp=tmp->next;
 	}
 }
 


### PR DESCRIPTION
Oof. So, that's why it's always the first node that gets removed.